### PR TITLE
Make JSON default response content type

### DIFF
--- a/scim-sdk/src/main/java/com/unboundid/scim/wink/BulkResource.java
+++ b/scim-sdk/src/main/java/com/unboundid/scim/wink/BulkResource.java
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright 2012-2019 Ping Identity Corporation
  *
  * This program is free software; you can redistribute it and/or modify

--- a/scim-sdk/src/main/java/com/unboundid/scim/wink/BulkResource.java
+++ b/scim-sdk/src/main/java/com/unboundid/scim/wink/BulkResource.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2012-2019 Ping Identity Corporation
  *
  * This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
 package com.unboundid.scim.wink;
 
 import com.unboundid.scim.sdk.OAuthTokenHandler;
+import org.glassfish.jersey.message.internal.Quality;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -70,7 +71,8 @@ public class BulkResource extends AbstractBulkResource
    */
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=1")
   public Response doJsonJsonPost(final InputStream inputStream,
                                  @Context final HttpServletRequest request,
                                  @Context final SecurityContext securityContext,
@@ -99,7 +101,8 @@ public class BulkResource extends AbstractBulkResource
    */
   @POST
   @Consumes(MediaType.APPLICATION_XML)
-  @Produces(MediaType.APPLICATION_XML)
+  @Produces(MediaType.APPLICATION_XML + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=0.5")
   public Response doXmlXmlPost(final InputStream inputStream,
                                @Context final HttpServletRequest request,
                                @Context final SecurityContext securityContext,
@@ -129,7 +132,8 @@ public class BulkResource extends AbstractBulkResource
    */
   @POST
   @Consumes(MediaType.APPLICATION_XML)
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=1")
   public Response doXmlJsonPost(final InputStream inputStream,
                                 @Context final HttpServletRequest request,
                                 @Context final SecurityContext securityContext,
@@ -159,7 +163,8 @@ public class BulkResource extends AbstractBulkResource
    */
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_XML)
+  @Produces(MediaType.APPLICATION_XML + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=0.5")
   public Response doJsonXmlPost(final InputStream inputStream,
                                 @Context final HttpServletRequest request,
                                 @Context final SecurityContext securityContext,

--- a/scim-sdk/src/main/java/com/unboundid/scim/wink/RootResource.java
+++ b/scim-sdk/src/main/java/com/unboundid/scim/wink/RootResource.java
@@ -19,6 +19,7 @@ package com.unboundid.scim.wink;
 
 import com.unboundid.scim.sdk.SCIMException;
 import com.unboundid.scim.sdk.SCIMResponse;
+import org.glassfish.jersey.message.internal.Quality;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -67,7 +68,8 @@ public class RootResource extends AbstractStaticResource
    * @return  The response to the request.
    */
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=1")
   public Response doJsonGet()
   {
     final SCIMResponse response = getResponse();
@@ -85,7 +87,8 @@ public class RootResource extends AbstractStaticResource
    * @return  The response to the request.
    */
   @GET
-  @Produces(MediaType.APPLICATION_XML)
+  @Produces(MediaType.APPLICATION_XML + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=0.5")
   public Response doXmlGet()
   {
     final SCIMResponse response = getResponse();

--- a/scim-sdk/src/main/java/com/unboundid/scim/wink/ServiceProviderConfigResource.java
+++ b/scim-sdk/src/main/java/com/unboundid/scim/wink/ServiceProviderConfigResource.java
@@ -18,6 +18,7 @@
 package com.unboundid.scim.wink;
 
 import com.unboundid.scim.data.ServiceProviderConfig;
+import org.glassfish.jersey.message.internal.Quality;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -55,7 +56,8 @@ public class ServiceProviderConfigResource extends AbstractStaticResource
    * @return  The response to the request.
    */
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=1")
   public Response doJsonGet()
   {
     final ServiceProviderConfig config = application.getServiceProviderConfig();
@@ -77,7 +79,8 @@ public class ServiceProviderConfigResource extends AbstractStaticResource
    * @return  The response to the request.
    */
   @GET
-  @Produces(MediaType.APPLICATION_XML)
+  @Produces(MediaType.APPLICATION_XML + ";"
+            + Quality.QUALITY_SOURCE_PARAMETER_NAME + "=0.5")
   public Response doXmlGet()
   {
     final ServiceProviderConfig config = application.getServiceProviderConfig();


### PR DESCRIPTION
According to RFC7644, when no format is provided
by accept header in a SCIM 1.1 request, the server must
default to JSON response format. A few of our
endpoints do not currently do this, so making
this the default for those endpoints.

===BEGIN-RELEASE-NOTE===
Made JSON the default SCIM 1.1 response content type
for requests that did not specify an accept content
type.
===END-RELEASE-NOTE===

Reviewer: Jacob Childress

JiraIssue: DS-40869

SalesforceCaseNumber: 00672865

Product: ds