### PR TITLE
Updated LDAPSDK dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## v1.8.26 - TBD
-[placeholder for next release]
+Updated the LDAPSDK to version 6.0.0 to avoid CVE-2018-1000134.
 
 ## v1.8.25 - 2020-08-24
 Update Release-Notes.txt

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.build.genSourceDirectory>${project.build.directory}/generated-sources</project.build.genSourceDirectory>
         <main.basedir>${project.basedir}</main.basedir>
         <ignore.test.failures>false</ignore.test.failures>
-        <ldapsdk.version>3.2.0</ldapsdk.version>
+        <ldapsdk.version>6.0.0</ldapsdk.version>
     </properties>
 
     <profiles>

--- a/scim-ldap/src/main/assemblies/pom.xml
+++ b/scim-ldap/src/main/assemblies/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
-            <version>2.3.6</version>
+            <version>${ldapsdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.unboundid.product.scim</groupId>


### PR DESCRIPTION
Updated the LDAPSDK to version 6.0.0 to avoid CVE-2018-1000134.

Reviewer: Lance Purple

JiraIssue: DS-44635