### PR TITLE
Updated HttpClient in SCIM SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## v1.8.26 - TBD
-[placeholder for next release]
+Updated Apache HttpClient to version 4.5.13 to avoid CVE-2020-13956.
 
 ## v1.8.25 - 2020-08-24
 Update Release-Notes.txt

--- a/scim-sdk/pom.xml
+++ b/scim-sdk/pom.xml
@@ -303,7 +303,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>com.unboundid</groupId>

--- a/scim-sdk/src/main/assemblies/pom.xml
+++ b/scim-sdk/src/main/assemblies/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.5</version>
+          <version>4.5.13</version>
         </dependency>
         <dependency>
           <groupId>org.apache.wink</groupId>


### PR DESCRIPTION
Updated Apache HttpClient to version 4.5.13 to avoid
CVE-2020-13956.

Reviewer: Lance Purple

JiraIssue: DS-44324